### PR TITLE
feat: Spring Security 설정 및 Google OAuth2 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,23 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
-	implementation 'org.projectlombok:lombok'
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// SWAGGER
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+
+	// LOMBOK
+	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// MONGO DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+	// SOCIAL LOGIN
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// TEST
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/depromeet/onepiece/common/config/SecurityConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package depromeet.onepiece.common.config;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http.cors(
+            corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+        .csrf(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .logout(AbstractHttpConfigurer::disable)
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(SWAGGER_PATTERNS)
+                    .permitAll()
+                    .requestMatchers(STATIC_RESOURCES_PATTERNS)
+                    .permitAll()
+                    .requestMatchers(PERMIT_ALL_PATTERNS)
+                    .permitAll()
+                    .requestMatchers(PUBLIC_ENDPOINTS)
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+        .build();
+  }
+
+  private static final String[] SWAGGER_PATTERNS = {
+    "/swagger-ui/**", "/actuator/**", "/v3/api-docs/**",
+  };
+
+  private static final String[] STATIC_RESOURCES_PATTERNS = {
+    "/img/**", "/css/**", "/js/**",
+  };
+
+  private static final String[] PERMIT_ALL_PATTERNS = {
+    "/error", "/favicon.ico", "/index.html", "/",
+  };
+
+  private static final String[] PUBLIC_ENDPOINTS = {
+    "/api/v1/**",
+  };
+
+  CorsConfigurationSource corsConfigurationSource() {
+    return request -> {
+      CorsConfiguration config = new CorsConfiguration();
+      config.setAllowedHeaders(Collections.singletonList("*"));
+      config.setAllowedMethods(Collections.singletonList("*"));
+      config.setAllowedOriginPatterns(List.of("http://localhost:3000"));
+      config.setAllowCredentials(true);
+      return config;
+    };
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,13 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: profile, email
+
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #12 

## 💡 작업내용
- SecurityFilterChain 및 CORS 허용 도메인 설정
- OAuth2 기반 환경 설정

## 📝 기타
- `GOOGLE_CLIENT_ID` 및 `GOOGLE_CLIENT_SECRET` 환경변수는 노션에 기록하였습니다.
