### PR TITLE
feat : pdf 파일 이미지 슬라이싱 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	implementation 'com.azure:azure-ai-openai:1.0.0-beta.12'
 
 	// PDF
-	implementation 'org.apache.pdfbox:pdfbox:2.0.27'
+	implementation 'org.apache.pdfbox:pdfbox:3.0.4'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,11 @@ dependencies {
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.11.238'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
-	//AZURE OPENAI SDK
+	// AZURE OPENAI SDK
 	implementation 'com.azure:azure-ai-openai:1.0.0-beta.12'
+
+	// PDF
+	implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 	implementation 'com.azure:azure-ai-openai:1.0.0-beta.12'
 
 	// PDF
-	implementation 'org.apache.pdfbox:pdfbox:3.0.4'
+	implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 }
 
 

--- a/src/main/java/depromeet/onepiece/feedback/command/infrastructure/FeedbackService.java
+++ b/src/main/java/depromeet/onepiece/feedback/command/infrastructure/FeedbackService.java
@@ -3,7 +3,6 @@ package depromeet.onepiece.feedback.command.infrastructure;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.validator.internal.constraintvalidators.bv.NullValidator;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,8 +11,6 @@ import org.springframework.stereotype.Service;
 public class FeedbackService {
 
   private final AzureService azureService;
-  private final ChatGPTProperties chatGPTProperties;
-  private final NullValidator nullValidator;
 
   public void portfolioFeedback(String fileId, String additionalChat) {
     List<String> fineUrls = getFileUrl(fileId);

--- a/src/main/java/depromeet/onepiece/file/command/infrastructure/ObjectStorageFileUploader.java
+++ b/src/main/java/depromeet/onepiece/file/command/infrastructure/ObjectStorageFileUploader.java
@@ -9,14 +9,20 @@ import depromeet.onepiece.file.command.exception.FileConvertErrorException;
 import depromeet.onepiece.file.command.exception.FileUploadFailedException;
 import depromeet.onepiece.file.domain.FileDocument;
 import depromeet.onepiece.file.domain.FileType;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -35,6 +41,19 @@ public class ObjectStorageFileUploader implements FileUploader {
 
   @Override
   public FileDocument upload(MultipartFile multipartFile, String logicalName, FileType fileType) {
+    try {
+      if (fileType == FileType.PORTFOLIO_PDF) {
+        return uploadPdfAsImages(multipartFile, logicalName, fileType);
+      } else {
+        return uploadSingleFile(multipartFile, logicalName, fileType);
+      }
+    } catch (Exception e) {
+      throw new FileUploadFailedException();
+    }
+  }
+
+  private FileDocument uploadSingleFile(
+      MultipartFile multipartFile, String logicalName, FileType fileType) {
     try {
       File fileToUpload = convert(multipartFile).orElseThrow(FileConvertErrorException::new);
       FileDocument fileDocumentToSave = FileDocument.create(new ObjectId(), logicalName, fileType);
@@ -80,5 +99,39 @@ public class ObjectStorageFileUploader implements FileUploader {
       case PORTFOLIO_PDF -> Path.of(fileId, "upload", fileName).toString();
       case PORTFOLIO_IMAGE -> Path.of(fileId, "processed", fileName).toString();
     };
+  }
+
+  private FileDocument uploadPdfAsImages(
+      MultipartFile multipartFile, String logicalName, FileType fileType) {
+    try {
+      File pdfFile = convert(multipartFile).orElseThrow(FileConvertErrorException::new);
+      List<String> uploadedFilePaths = new ArrayList<>();
+      ObjectId fileId = new ObjectId();
+
+      try (PDDocument document = PDDocument.load(pdfFile)) {
+        PDFRenderer pdfRenderer = new PDFRenderer(document);
+        for (int page = 0; page < document.getNumberOfPages(); page++) {
+          BufferedImage image = pdfRenderer.renderImageWithDPI(page, 300);
+          String imageName = (page + 1) + ".png";
+          File imageFile = new File(imageName);
+          ImageIO.write(image, "png", imageFile);
+
+          String filePath = Path.of(fileId.toString(), "processed", imageName).toString();
+          amazonS3.putObject(
+              new PutObjectRequest(bucketName, filePath, imageFile)
+                  .withCannedAcl(CannedAccessControlList.Private));
+
+          uploadedFilePaths.add(filePath);
+          removeUploadedFile(imageFile);
+        }
+      }
+
+      removeUploadedFile(pdfFile);
+      return fileRepository.save(
+          FileDocument.create(fileId, logicalName, fileType)
+              .setPhysicalPath(String.join(",", uploadedFilePaths)));
+    } catch (IOException e) {
+      throw new FileUploadFailedException();
+    }
   }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #40 

## 💡 작업내용
NCP 오브젝트 스토리지에 pdf를 업로드할 때  이미지 슬라이싱 로직도 같이 진행되게 했습니다.
png 파일로 다 변환한 후 processed 폴더에 1.png, 2.png 형태로 저장됩니다.


## 📸 스크린샷(선택)
<img width="940" alt="image" src="https://github.com/user-attachments/assets/1dd97766-e260-4d9d-a2c4-888102d42690" />

## 📝 기타
string으로 저장되다보니, 1.png. 10.png ... 19.png -> 2.png, 20.png 이런 순서로 저장되는데, 이미지 전달할 때 이미지 개수만 파악한 후 1.png, 2.png .. 이렇게 한 번에 전달할 예정이라 문제는 없을 것 같습니다.

