### PR TITLE
fix : 이미지 해상도 줄이기

### DIFF
--- a/src/main/java/depromeet/onepiece/file/command/infrastructure/ObjectStorageFileUploader.java
+++ b/src/main/java/depromeet/onepiece/file/command/infrastructure/ObjectStorageFileUploader.java
@@ -87,7 +87,7 @@ public class ObjectStorageFileUploader implements FileUploader {
       try (PDDocument document = PDDocument.load(pdfFile)) {
         PDFRenderer pdfRenderer = new PDFRenderer(document);
         for (int page = 0; page < document.getNumberOfPages(); page++) {
-          BufferedImage image = pdfRenderer.renderImageWithDPI(page, 300);
+          BufferedImage image = pdfRenderer.renderImageWithDPI(page, 30);
           String imageName = (page + 1) + ".png";
           File imageFile = new File(imageName);
           ImageIO.write(image, "png", imageFile);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #53 

## 💡 작업내용
해상도가 높아 이미지 50장으로 응답 받을 때 request 토큰이 100만 개가 넘는 문제가 있어, 이미지 추출할 때 해상도 낮춰서 저장되게 수정했습니다.

## 📸 스크린샷(선택)
<img width="407" alt="image" src="https://github.com/user-attachments/assets/f2f698be-ff05-46ac-9834-b34db06db7cf" />


## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
