### PR TITLE
fix: critix.kr:3000 CORS 허용

### DIFF
--- a/src/main/java/depromeet/onepiece/common/config/SecurityConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/SecurityConfig.java
@@ -94,7 +94,8 @@ public class SecurityConfig {
       CorsConfiguration config = new CorsConfiguration();
       config.setAllowedHeaders(Collections.singletonList("*"));
       config.setAllowedMethods(Collections.singletonList("*"));
-      config.setAllowedOriginPatterns(List.of("http://localhost:3000", "https://dev.critix.kr"));
+      config.setAllowedOriginPatterns(
+          List.of("http://localhost:3000", "https://dev.critix.kr", "https://critix.kr:3000"));
       config.setAllowCredentials(true);
       return config;
     };


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #73 

## 💡 작업내용

- critix.kr:3000 CORS 허용

## 📝 기타
클라이언트 팀 로컬 테스트 요청 URL 입니다
