### PR TITLE
feat: kafka 메시지 dto 설계 및 api 요청 interceptor 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,10 @@ dependencies {
 
 	//JACKSON
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0'
-
 	implementation 'com.fasterxml.jackson.module:jackson-module-jsonSchema:2.15.0'
 
+	// KAFKA
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 

--- a/src/main/java/depromeet/onepiece/common/config/KafkaConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/KafkaConfig.java
@@ -1,7 +1,8 @@
 package depromeet.onepiece.common.config;
 
+import static org.apache.kafka.common.requests.CreateTopicsRequest.NO_REPLICATION_FACTOR;
+
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,6 @@ public class KafkaConfig {
 
   @Bean
   public NewTopic topic1() {
-    return new NewTopic(topic, 3, CreateTopicsRequest.NO_REPLICATION_FACTOR);
+    return new NewTopic(topic, 3, NO_REPLICATION_FACTOR);
   }
 }

--- a/src/main/java/depromeet/onepiece/common/config/KafkaConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/KafkaConfig.java
@@ -1,0 +1,21 @@
+package depromeet.onepiece.common.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.requests.CreateTopicsRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+  @Value("${spring.kafka.template.default-topic}")
+  private String topic;
+
+  @Bean
+  public NewTopic topic1() {
+    return new NewTopic(topic, 3, CreateTopicsRequest.NO_REPLICATION_FACTOR);
+  }
+}

--- a/src/main/java/depromeet/onepiece/common/config/WebMvcConfig.java
+++ b/src/main/java/depromeet/onepiece/common/config/WebMvcConfig.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import depromeet.onepiece.common.auth.resolver.CurrentUserArgumentResolver;
+import depromeet.onepiece.common.eventsourcing.interceptor.GptEventInterceptor;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +19,14 @@ import org.bson.types.ObjectId;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
   private final CurrentUserArgumentResolver currentUserArgumentResolver;
+  private final GptEventInterceptor gptEventInterceptor;
 
   @Bean
   public JsonMapper objectMapper() {
@@ -61,5 +64,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(currentUserArgumentResolver);
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(gptEventInterceptor);
   }
 }

--- a/src/main/java/depromeet/onepiece/common/eventsourcing/dto/GptFeedbackStatusTopic.java
+++ b/src/main/java/depromeet/onepiece/common/eventsourcing/dto/GptFeedbackStatusTopic.java
@@ -1,0 +1,42 @@
+package depromeet.onepiece.common.eventsourcing.dto;
+
+import depromeet.onepiece.feedback.domain.FeedbackStatus;
+import java.util.UUID;
+import lombok.Builder;
+import org.bson.types.ObjectId;
+
+@Builder
+public record GptFeedbackStatusTopic(
+    String id,
+    ObjectId userId,
+    ObjectId portfolioFileId,
+    FeedbackStatus feedbackStatus,
+    FeedbackStatus projectStatus,
+    int retryCount) {
+  public static GptFeedbackStatusTopic of(
+      ObjectId userId,
+      ObjectId portfolioFileId,
+      FeedbackStatus feedbackStatus,
+      FeedbackStatus projectStatus,
+      int retryCount) {
+    return GptFeedbackStatusTopic.builder()
+        .id(UUID.randomUUID().toString())
+        .userId(userId)
+        .portfolioFileId(portfolioFileId)
+        .feedbackStatus(feedbackStatus)
+        .projectStatus(projectStatus)
+        .retryCount(retryCount)
+        .build();
+  }
+
+  public static GptFeedbackStatusTopic increaseRetryCount(GptFeedbackStatusTopic topic) {
+    return GptFeedbackStatusTopic.builder()
+        .id(topic.id())
+        .userId(topic.userId())
+        .portfolioFileId(topic.portfolioFileId())
+        .feedbackStatus(topic.feedbackStatus())
+        .projectStatus(topic.projectStatus())
+        .retryCount(topic.retryCount() + 1)
+        .build();
+  }
+}

--- a/src/main/java/depromeet/onepiece/common/eventsourcing/interceptor/GptEventInterceptor.java
+++ b/src/main/java/depromeet/onepiece/common/eventsourcing/interceptor/GptEventInterceptor.java
@@ -1,0 +1,51 @@
+package depromeet.onepiece.common.eventsourcing.interceptor;
+
+import static depromeet.onepiece.feedback.domain.FeedbackStatus.PENDING;
+
+import depromeet.onepiece.common.eventsourcing.dto.GptFeedbackStatusTopic;
+import depromeet.onepiece.common.eventsourcing.service.KafkaGptEventProducer;
+import depromeet.onepiece.user.query.application.CurrentUserIdService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class GptEventInterceptor implements HandlerInterceptor {
+  private final CurrentUserIdService currentUserIdService;
+  private final KafkaGptEventProducer kafkaGptEventProducer;
+
+  @Value("${spring.kafka.intercept-uri}")
+  private String interceptUri;
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (request.getRequestURI().equals(interceptUri)) {
+      String fileIdParam = request.getParameter("fileId");
+      if (fileIdParam == null || fileIdParam.isEmpty()) {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return false;
+      }
+
+      ObjectId userId =
+          currentUserIdService.getCurrentUserId(
+              Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                  .map(Authentication::getName)
+                  .orElse(null));
+      ObjectId fileId = new ObjectId(fileIdParam);
+
+      kafkaGptEventProducer.produceTopic(
+          GptFeedbackStatusTopic.of(
+              userId, fileId, PENDING, PENDING, 0)); // TODO: retry count 받아오기 필요함
+    }
+    return true;
+  }
+}

--- a/src/main/java/depromeet/onepiece/common/eventsourcing/service/KafkaGptEventProducer.java
+++ b/src/main/java/depromeet/onepiece/common/eventsourcing/service/KafkaGptEventProducer.java
@@ -1,0 +1,37 @@
+package depromeet.onepiece.common.eventsourcing.service;
+
+import depromeet.onepiece.common.eventsourcing.dto.GptFeedbackStatusTopic;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaGptEventProducer {
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+
+  @Value("${spring.kafka.template.default-topic}")
+  private String topic;
+
+  public void produceTopic(final GptFeedbackStatusTopic topicDto) {
+    kafkaTemplate
+        .send(topic, topicDto.id(), topicDto)
+        .whenComplete(
+            (result, throwable) -> {
+              if (throwable != null) {
+                log.error("fail to send message, {}", throwable.getMessage());
+              } else {
+                RecordMetadata metadata = result.getRecordMetadata();
+                log.info(
+                    "message sent to topic: {}, partition: {}, offset: {}",
+                    metadata.topic(),
+                    metadata.partition(),
+                    metadata.offset());
+              }
+            });
+  }
+}

--- a/src/main/java/depromeet/onepiece/feedback/command/presentation/FeedbackCommandController.java
+++ b/src/main/java/depromeet/onepiece/feedback/command/presentation/FeedbackCommandController.java
@@ -26,9 +26,8 @@ public class FeedbackCommandController {
       description = "fileId 받아 포트폴리오 피드백 API 호출 후 feedbackId 반환하는 API [담당자 : 김수진]")
   @GetMapping(value = "/start")
   public ResponseEntity<CustomResponse<StartFeedbackResponse>> startFeedback(
-      @RequestParam(value = "fileId") ObjectId fileId, @CurrentUserId String userId) {
-    StartFeedbackResponse response =
-        feedbackCommandFacadeService.startFeedback(new ObjectId(userId), fileId);
+      @RequestParam(value = "fileId") ObjectId fileId, @CurrentUserId ObjectId userId) {
+    StartFeedbackResponse response = feedbackCommandFacadeService.startFeedback(userId, fileId);
     return CustomResponse.okResponseEntity(response);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ spring:
       bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
       client-id: kafka-producer
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         spring.json.trusted.packages: depromeet.onepiece.common.eventsourcing.dto
     listener:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,7 @@ spring:
     listener:
       concurrency: 3
       ack-mode: record
+    intercept-uri: ${KAFKA_INTERCEPT_URI:/api/v1/feedback/start}
 
 springdoc:
   default-consumes-media-type: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,28 @@ spring:
       max-file-size: ${MAX_FILE_SIZE:50MB}
       max-request-size: ${MAX_REQUEST_SIZE:50MB}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    template:
+      default-topic: ${KAFKA_TOPIC:gpt-limiter}
+    consumer:
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      client-id: kafka-consumer
+      group-id: gpt-limiter-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    producer:
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      client-id: kafka-producer
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages:
+    listener:
+      concurrency: 3
+      ack-mode: record
+
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
-        spring.json.trusted.packages:
+        spring.json.trusted.packages: depromeet.onepiece.common.eventsourcing.dto
     listener:
       concurrency: 3
       ack-mode: record


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #90 

## 💡 작업내용

- api 요청 가로채서 kafka에 메시지 전송하도록 interceptor 구현
- topic에 전송할 DTO 설계
- kafka producer 구현

## 📝 기타
로컬 kafka에서 topic에 메시지 정상적으로 들어오는 것 확인했습니다.
