### PR TITLE
feat : NCP Cloud Function Trigger 파일 업로드

### DIFF
--- a/src/main/java/depromeet/onepiece/file/command/infrastructure/ObjectStorageFileUploader.java
+++ b/src/main/java/depromeet/onepiece/file/command/infrastructure/ObjectStorageFileUploader.java
@@ -49,9 +49,9 @@ public class ObjectStorageFileUploader implements FileUploader {
 
   private void removeUploadedFile(File targetFile) {
     if (targetFile.delete()) {
-      log.info("File deleted successfully");
+      log.info("파일 삭제 성공");
     } else {
-      log.warn("Failed to delete the file");
+      log.warn("파일 삭제 실패");
     }
   }
 
@@ -81,7 +81,7 @@ public class ObjectStorageFileUploader implements FileUploader {
       amazonS3.putObject(
           new PutObjectRequest(bucketName, pdfUploadPath, pdfFile)
               .withCannedAcl(CannedAccessControlList.Private));
-      log.info("PDF uploaded to S3: " + pdfUploadPath);
+      log.info("PDF 업로드: " + pdfUploadPath);
 
       try (PDDocument document = PDDocument.load(pdfFile)) {
         PDFRenderer pdfRenderer = new PDFRenderer(document);
@@ -95,7 +95,7 @@ public class ObjectStorageFileUploader implements FileUploader {
           amazonS3.putObject(
               new PutObjectRequest(bucketName, processedPath, imageFile)
                   .withCannedAcl(CannedAccessControlList.Private));
-          log.info("Image uploaded to S3: " + processedPath);
+          log.info("이미지 업로드: " + processedPath);
 
           uploadedFilePaths.add(processedPath);
           removeUploadedFile(imageFile);
@@ -113,20 +113,27 @@ public class ObjectStorageFileUploader implements FileUploader {
   }
 
   private void uploadCompletedFile(ObjectId fileId) {
-    File completedFile = new File("completed.txt");
+    File completedFile = null;
     try {
-      if (!completedFile.exists()) {
-        completedFile.createNewFile();
-      }
+      completedFile = File.createTempFile("completed-" + fileId, ".txt");
+      String completedFilePath =
+          Path.of(fileId.toString(), "processed", "completed.txt").toString();
+      amazonS3.putObject(
+          new PutObjectRequest(bucketName, completedFilePath, completedFile)
+              .withCannedAcl(CannedAccessControlList.Private));
+
+      log.info("트리거 파일 업로드: " + completedFilePath);
+
     } catch (IOException e) {
-      log.error("Failed to create completed.txt file", e);
+      log.error("임시 파일 에러", e);
       throw new FileUploadFailedException();
+    } finally {
+      if (completedFile != null && completedFile.exists()) {
+        boolean deleted = completedFile.delete();
+        if (!deleted) {
+          log.warn("임시 파일 삭제 실패 : " + completedFile.getAbsolutePath());
+        }
+      }
     }
-    String completedFilePath = Path.of(fileId.toString(), "processed", "completed.txt").toString();
-    amazonS3.putObject(
-        new PutObjectRequest(bucketName, completedFilePath, completedFile)
-            .withCannedAcl(CannedAccessControlList.Private));
-    log.info("Completed file uploaded to S3: " + completedFilePath);
-    removeUploadedFile(completedFile);
   }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #101 

## 💡 작업내용
NCP Cloud Functon 트리거로 사용하는 `completed.txt` 파일을 업로드하는 로직 구현

### 파일 가공 및 업로드 로직 정리
1. 파일 업로드 API 호출
2. upload 폴더에 PDF 업로드
3. PDF 이미지 파일로 슬라이싱
4. processed 폴더에 이미지 업로드
5. 모든 이미지가 업로드되면 processed 폴더에 completed.txt 업로드 ← `현재 PR`
6. NCP Cloud Function이 업로드를 감지해 OCR 호출 후 ocr 폴더에 result.json 반환

<img width="719" alt="image" src="https://github.com/user-attachments/assets/9582beec-d61b-4afc-b964-d9bbb77f4a91" />

## 📸 스크린샷(선택)
|폴더 구조|processed 폴더|
|--|--|
|<img width="375" alt="image" src="https://github.com/user-attachments/assets/d38563c4-ae08-4389-81ad-7f23bf8dd0c0" />|<img width="550" alt="image" src="https://github.com/user-attachments/assets/8f29d681-dab4-4022-96e8-5450f998df8c" />|


## 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
