### PR TITLE
feat: 로그아웃 API 구현

### DIFF
--- a/src/main/java/depromeet/onepiece/common/auth/application/service/AuthService.java
+++ b/src/main/java/depromeet/onepiece/common/auth/application/service/AuthService.java
@@ -51,6 +51,11 @@ public class AuthService {
     return tokenResult;
   }
 
+  public void logout(HttpServletRequest request, HttpServletResponse response) {
+    refreshTokenService.invalidateRefreshToken(request, response);
+    log.info("User {} logged out", maskId(request.getRemoteAddr()));
+  }
+
   private TokenResult handleExistUser(User user, AuthAttributes attributes) {
     if (user.hasDifferentProviderWithEmail(attributes.getEmail(), attributes.getExternalId()))
       throw new AlreadyRegisteredUserException();

--- a/src/main/java/depromeet/onepiece/common/auth/presentation/AuthController.java
+++ b/src/main/java/depromeet/onepiece/common/auth/presentation/AuthController.java
@@ -25,4 +25,11 @@ public class AuthController {
       HttpServletRequest request, HttpServletResponse response) {
     return new CustomResponse<>(authService.reissueToken(request, response));
   }
+
+  @PostMapping("/logout")
+  @Operation(summary = "로그아웃 API", description = "로그아웃 API [담당자 : 이한음]")
+  public CustomResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+    authService.logout(request, response);
+    return CustomResponse.ok();
+  }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #121 

## 💡 작업내용

- 로그아웃 API를 구현, 리프레시 토큰 삭제

## 📸 스크린샷(선택)

## 📝 기타
로그아웃 api 호출 시 쿠키에 저장된 유저의 리프레시 토큰이 만료 됩니다.
